### PR TITLE
[LIFE-2060] Feature/dc add simple install

### DIFF
--- a/android_emulator_cli.sh
+++ b/android_emulator_cli.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
+
+
+
+#~/Library/Android/sdk/cmdline-tools/latest/bin/sdkmanager --list --channel=0 | awk '{ print $NF,$0|"sort -n -k1" }' | grep 'Android SDK Platform.*' | tail -2 | head -1
+#~/Library/Android/sdk/cmdline-tools/latest/bin/sdkmanager --list --channel=0 | grep 'Android SDK Platform.*' | awk '{ print $NF,$0|"sort -n -k1" }' | tail -2 | head -1
+# Get's second latest API version (In case we don't yet support the latest API)
+#~/Library/Android/sdk/cmdline-tools/latest/bin/sdkmanager --list --channel=0 | grep -o 'platforms;android-[0-9][0-9]' | awk -F"android-" '/android-/{ print $2}' | tail -2 | head -1
+
+
+########################################################
+# Intro START
 echo
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 echo
@@ -32,11 +43,42 @@ echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 echo "Welcome to the Android Emulator CLI only script!"
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 sleep .5
+
+# Intro END
+########################################################
+# Main Menu START
+
+# PS3='Please enter your choice'
+# options=""
+
+
+# Main Menu END
+########################################################
+# CPU Detection START
+
+CPU_ABI=$(arch)
+# CPU_NAME=$(sysctl -n machdep.cpu.brand_string)
+if [[ "$CPU_ABI" == "arm64" ]]; then 
+	CPU_ABI="arm64-v8a";
+elif [[ "$CPU_ABI" == "i386" ]] | [[ "$CPU_API" == "x86_64" ]]; then
+	CPU_ABI="x86_64";
+else
+	echo "ERROR: No recognizable CPU / ABI was found. Cannont continue with installation.";
+	exit;
+fi
+echo "** CPU Found: $CPU_ABI **"
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+
+# CPU Detection END
+########################################################
+# Java START
+
 echo "** Checking for already installed files **"
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 echo "Checking for current JDK versions"
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 
+wait
 JAVA_VERSION=$(java -version 2>&1 | awk '/version/{print $NF}')
 # Is Java 8 Installed?
 if echo $JAVA_VERSION | grep -q 1.8; then
@@ -58,17 +100,14 @@ else
 	echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 fi
 
-# Command line tools used to be here
-FILE1=~/Library/Android/sdk/tools/bin/sdkmanager
-# But now they should reside here
-FILE2=~/Library/Android/sdk/cmdline-tools/latest/bin/sdkmanager
-# if [ -f "$FILE1" ]; then
-	# echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-	# echo "Android CLI Tools already installed, moving on."
-	# echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-# el
+# Java END
+########################################################
+# Android CLI Tools START
 
-if [ -f "$FILE2" ]; then
+# Command line tools used to have another location but now resides here.
+FILE1=~/Library/Android/sdk/cmdline-tools/latest/bin/sdkmanager
+
+if [ -f "$FILE1" ]; then
 	echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 	echo "Android CLI Tools already installed, moving on."
 	echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
@@ -93,26 +132,66 @@ fi
 export ANDROID_SDK_ROOT=~/Library/Android/sdk
 export ANDROID_HOME=~/Library/Android/sdk
 export PATH=$PATH:$ANDROID_HOME/cmdline-tools/latest/bin/
+
+# Android CLI Tools END
+########################################################
+# SDKManager Platform-Tools & Emulator START
+
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 echo "Ensuring that you are updated to the latest version."
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 echo "Downloading Android Platform Tools and Emulator files."
-yes | ~/Library/Android/sdk/cmdline-tools/latest/bin/sdkmanager platform-tools emulator
+wait
+~/Library/Android/sdk/cmdline-tools/latest/bin/sdkmanager platform-tools emulator
+wait
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 echo ""
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-echo "Downloading Android API 29 files."
-yes | ~/Library/Android/sdk/cmdline-tools/latest/bin/sdkmanager "platforms;android-29"
+echo ""
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+
+sleep .5
+echo "Getting Recommended Android API"
+ANDROID_API=$(~/Library/Android/sdk/cmdline-tools/latest/bin/sdkmanager --list --channel=0 | grep -o 'platforms;android-[0-9][0-9]' | awk -F"android-" '/android-/{ print $2}' | tail -2 | head -1)
+wait
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 echo ""
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-echo "Downloading an Android API 29 System Image."
-yes | ~/Library/Android/sdk/cmdline-tools/latest/bin/sdkmanager "system-images;android-29;google_apis_playstore;x86_64"
+echo ""
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+
+sleep .5
+echo "Downloading Android API $ANDROID_API files."
+wait
+~/Library/Android/sdk/cmdline-tools/latest/bin/sdkmanager "platforms;android-$ANDROID_API"
+wait
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 echo ""
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+echo ""
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+
+sleep .5
+echo "Downloading an Android API $ANDROID_API System Image."
+~/Library/Android/sdk/cmdline-tools/latest/bin/sdkmanager "system-images;android-$ANDROID_API;google_apis_playstore;$CPU_ABI"
+sleep 10
+wait
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+echo ""
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+echo ""
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+
+sleep .5
+
 echo "Downloading Android Platform Tools and Emulator files."
-yes | ~/Library/Android/sdk/cmdline-tools/latest/bin/sdkmanager "build-tools;29.0.3"
+wait
+BUILD_TOOLS=$(~/Library/Android/sdk/cmdline-tools/latest/bin/sdkmanager --list | grep "build-tools"  | tail -1 | cut -f1 -d'|' | sed 's: ::g' )
+wait
+echo "Build tools found: $BUILD_TOOLS"
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+~/Library/Android/sdk/cmdline-tools/latest/bin/sdkmanager "$BUILD_TOOLS"
+wait
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 echo ""
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
@@ -120,15 +199,43 @@ echo ""
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 echo "Updating emulator files"
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+wait
 yes | ~/Library/Android/sdk/cmdline-tools/latest/bin/sdkmanager --update
+wait
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+echo ""
+
+sleep .5
+
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+# Need to accept licenses for any installed packages 
+# https://developer.android.com/studio/command-line/sdkmanager#accept-licenses
+# If already accepted, then will skip.
+echo "Checking if any Licenses need to be accepted"
+wait
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+yes | ~/Library/Android/sdk/cmdline-tools/latest/bin/sdkmanager --licenses
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+echo ""
+
+sleep .5
+
+# SDKManager Platform-Tools & Emulator END
+########################################################
+# Android Emulator creation & launch START
+
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 echo "Creating a new Android Emulator."
+wait
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-echo "no" | ~/Library/Android/sdk/cmdline-tools/latest/bin/avdmanager create avd -n PixelXL29 -d "pixel_xl" -k "system-images;android-29;google_apis_playstore;x86_64"
+echo "no" | ~/Library/Android/sdk/cmdline-tools/latest/bin/avdmanager create avd -n PixelXL29 -d "pixel_xl" -k "system-images;android-$ANDROID_API;google_apis_playstore;$CPU_ABI" --force
 echo ""
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 echo "Setting emulator hardware settings."
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+
+sleep .5
+
 
 # Need to evaluate this path to set a skin
 SKIN_PATH=~/Library/Android/sdk/skins/pixel_2_xl
@@ -142,10 +249,16 @@ SKIN_PATH_VAL="skin.path = $SKIN_PATH"
 	echo 'hw.gpu.mode = auto'
 	echo 'hw.initialOrientation = Portrait'
 	echo 'hw.keyboard = yes'
+	echo "image.sysdir.1=system-images/android-$ANDROID_API/google_apis_playstore/$CPU_ABI/"
 	echo $SKIN_PATH_VAL
 } >> ~/.android/avd/PixelXL29.avd/config.ini
 
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 echo "Launching your fresh new emulator!"
+wait
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-yes | ~/Library/Android/sdk/tools/emulator -avd PixelXL29 &
+yes | ~/Library/Android/sdk/emulator/emulator -avd PixelXL29 &
+
+# Android Emulator creation & launch END
+########################################################
+# EOF


### PR DESCRIPTION
### Problem:

About a month ago, there was a post in [Slack](https://ibotta.slack.com/archives/C7M14QU0H/p1665678090676249) where it was reported that the Android CLI tool was broken. Turns out the issue was caused by the hardcoding for `Intel Processors` of `x86_64`. Now that _some_ of us have `M1 processors` the original script won't work. And because not everyone has an `M1 processor` MacBook yet, we need this script to be a little more flexible. Which got me thinking...

### Idea:
What if... this script was a _little_ more flexible and gave some custom install options along with some other helpful tools.

### Plan:
My plan is to update this script in several phases to include more options:

1. `Simple Install`- Automatically detects your processor type, grabs the _second latest_ Android API version and installs everything similar to how it works now (ie. This PR).
2. `Manual Install` - Allows the user to install a specific Android API version and select which Android emulator "skin" they would like.
3. `Run Emulator` - Instead of running through the script installs every time for one specific emulator, just perform a minor tools update, provide a list of installed emulators and launch it.
4. `Check APK versioning` - Allows the user to past in the path of an SDK and check the `minimum Android API version` and the `target Android API version` of the specific APK. This would allow users to know if their emulator's API version is out of date.
5. `Add a Main Menu` - Would allow users to select which option they would like to choose from (from the options mentioned above)
6. `Update the Readme` in this repo with links to all of the tools being installed for more information.

### Documentation:
* You can find a flow chart of the design here (Please slack me or comment in this PR with any feedback!) : https://lucid.app/lucidchart/510e360e-1afc-49a7-bf5e-72fb473cd701/edit?page=0_0&invitationId=inv_2eb1c702-8a7d-4a0a-9943-62e826e80e94#
* https://developer.android.com/studio/command-line
* https://ibotta.atlassian.net/browse/LIFE-2060

### What's in this PR:
This PR only covers the `Simple Install` mentioned above. To test the changes are a little tricky however. Running it locally can give you a variety of results. If the `Android Command Line tool` are already installed, it should "just work". If they are not, sometimes it will work, other times some of the scripts can fail do to an error called "Tag Mismatch".

```
Downloading an Android API 32 System Image for arm64-v8a.
Warning: An error occurred while preparing SDK package Google Play ARM 64 v8a System Image: Tag mismatch!.
```

From what I've gathered ([here](https://stackoverflow.com/questions/24791678/android-sdk-manager-doesnt-work-download-interrupted-tag-mismatch) and [here](https://stackoverflow.com/questions/37369775/unknown-error-for-google-apis-intel-x86-atom-system-image-android-studio)), this can happen for a variety of reasons. Sometimes it's space, sometimes it's security, sometimes it's the connection speed (:what_in_tarnation:). I _believe_ the hosting of the script solves this issue because I have not run into that issue running the `curl` command. I might experiment with the `wait` command if this continues to be an issue.

So with all of that said, you can try downloading the Zip file from my Google Drive and running it locally. Otherwise, IMO, we can merge these changes in and testing it afterwards using the `curl` command. Since it's already broken for a good portion of engineering and not a major dependency for any of our processes, potentially "breaking it more" seems trivial. 

To test it locally:

1. Download the `android-emulator-cli.zip` file from my Google Drive folder
2. Unzip it
3. In `terminal` run `bash android_emulator_cli.sh`
4. Emulator should launch if there are no issues during install.

To test it remotely (either the original script or once the fix is merged in):
1. In `terminal` run `curl -s https://ibotta.github.io/android-emulator-cli/android_emulator_cli.sh | bash`
2. Emulator should launch if there are no issues during install.

To make sure the installation is happening correctly:

1. In `Finder` go to `~/Library/Android/`
3. Rename the `sdk` folder to `sdk_original`
4. Run script
5. Make sure that a new `sdk` folder is created
6. In `~/<user name>/.android/avd` the new emulator should be listed (And also can be found in the Device Manager of Android Studio).

Let me know what you think!