### PR TITLE
[LIFE-2060] Remove unnecessary reminder prompt

### DIFF
--- a/android_emulator_cli.sh
+++ b/android_emulator_cli.sh
@@ -35,20 +35,6 @@ echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 echo "Welcome to the Android Emulator CLI only script!"
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 
-sleep 1
-
-echo; echo;
-echo "**** REQUIRED ****   Have you 'Requested administer access' yet before installation? (1/2)   **** REQUIRED ****"
-echo; echo;
-select yn in "Yes" "No"; do
-	case $yn in
-		Yes ) break;;
-		No ) echo "Exiting"; exit;;
-		* ) echo "Error: Did not recognize input. Please enter 1 or 2.";;
-	esac
-done
-
-
 # Intro END
 ########################################################
 # CPU Detection START


### PR DESCRIPTION
tl;dr: Not sure what's happening with the "reminder" menu prompt when mixed with the `curl` command, but it errors out after it's run. Removing it for now and will have to re-evaluate the idea of adding a prompt. 

Previous PR for reference: https://github.com/Ibotta/android-emulator-cli/pull/3