### PR TITLE
[LIFE-2060] CPU check fix

### DIFF
--- a/android_emulator_cli.sh
+++ b/android_emulator_cli.sh
@@ -39,16 +39,16 @@ echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 ########################################################
 # CPU Detection START
 
-CPU_ABI=""
 CPU_ARCH="$(arch)"
+CPU_ABI=""
 if [[ $CPU_ARCH == "arm64" ]]; then 
 	CPU_ABI="arm64-v8a";
-else
+elseß
 	CPU_ABI="x86_64";
 fi
 echo "** CPU Found: $CPU_ABI **"
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-exit;
+
 # CPU Detection END
 ########################################################
 # Java START
@@ -151,6 +151,7 @@ echo ""
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 
 sleep .5
+
 echo "Downloading an Android API $ANDROID_API System Imag for $CPU_ABI."
 SYSTEM_IMAGE="system-images;android-$ANDROID_API;google_apis_playstore;$CPU_ABI"
 yes | ~/Library/Android/sdk/cmdline-tools/latest/bin/sdkmanager $SYSTEM_IMAGE

--- a/android_emulator_cli.sh
+++ b/android_emulator_cli.sh
@@ -39,19 +39,16 @@ echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 ########################################################
 # CPU Detection START
 
-CPU_ARCH=$(arch)
 CPU_ABI=""
-if [[ "$CPU_ARCH" == "arm64" ]]; then 
+CPU_ARCH="$(arch)"
+if [[ $CPU_ARCH == "arm64" ]]; then 
 	CPU_ABI="arm64-v8a";
-elif [[ "$CPU_ARCH" == "i386" ]] | [[ "$CPU_ARCH" == "x86_64" ]]; then
-	CPU_ABI="x86_64";
 else
-	echo "ERROR: No recognizable CPU / ABI was found. Cannot continue with installation.";
-	exit;
+	CPU_ABI="x86_64";
 fi
 echo "** CPU Found: $CPU_ABI **"
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-
+exit;
 # CPU Detection END
 ########################################################
 # Java START

--- a/android_emulator_cli.sh
+++ b/android_emulator_cli.sh
@@ -39,11 +39,11 @@ echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 ########################################################
 # CPU Detection START
 
-CPU_ARCH="$(arch)"
+CPU_ARCH=$(arch)
 CPU_ABI=""
 if [[ $CPU_ARCH == "arm64" ]]; then 
 	CPU_ABI="arm64-v8a";
-elseß
+else
 	CPU_ABI="x86_64";
 fi
 echo "** CPU Found: $CPU_ABI **"


### PR DESCRIPTION
### Problem

For whatever reason, the check for `i386` is failing for older machines. I've attempted to temporarily change the instruction set for my machine to test it out more thoroughly but that hasn't bared any results yet.

Since this is now blocking people, I'm going to merge in the fix for any processor that's not an `arm` use `x86_64` for the instruction set. This is falls in-line with the original hardcoded values.

# What's next

Going to be contacting IT around potentially blocked scripts that are failing more often now than before (which didn't change).

### How to test

Run the script with a machine with a `CPU < M1`.